### PR TITLE
fix: ensure header remains visible at top on iPad scroll behavior

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -27,6 +27,13 @@ const Header = () => {
     const handleScroll = () => {
       const currentScrollY = window.scrollY;
 
+      // iOS 대응: 최상단이면 무조건 등장
+      if (currentScrollY <= 0) {
+        setIsVisible(true);
+        lastScrollY.current = 0;
+        return;
+      }
+
       if (currentScrollY > lastScrollY.current) {
         setIsVisible(false); // down, hide
       } else {


### PR DESCRIPTION
## Overview
This PR fixes an issue where the header could remain hidden when the page was scrolled back to the top on iPad browsers.
Due to the scroll behavior in iOS-based browsers, additional scroll events could occur at the top of the page, causing the header visibility logic to misinterpret the scroll direction. A safeguard was added to ensure the header remains visible when the scroll position reaches the top of the page.

## Changes
- Add safeguard logic to ensure the header is visible when the scroll position is at the top
- Improve compatibility with iOS / iPad scroll behavior
- Prevent the header from remaining hidden after returning to the top of the page

<br>